### PR TITLE
Update python_version for 3.13

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13

--- a/specteropsbloodhound.json
+++ b/specteropsbloodhound.json
@@ -7,7 +7,7 @@
     "logo": "specteropsbloodhound.svg",
     "logo_dark": "specteropsbloodhound_dark.svg",
     "product_name": "Specterops Bloodhound",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "product_version_regex": ".*",
     "publisher": "SpecterOps",
     "license": "Copyright (c) SpecterOps, 2025",


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)